### PR TITLE
Scripted installation/upgrade and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # brewupdate #
 
-brewupdate is a [launchd agent][launchd] to update [homebrew][homebrew] formulae automaticly every day at 11 AM (local time).
+brewupdate is a [launchd agent][launchd] to update [homebrew][homebrew] formulae automatically every day at 11 AM (local time).
 
-Brewupdate will not upgrade your installed formulae. It's sole responsibility is to fetch new formulae.
+Brewupdate will not upgrade your installed formulae. Its sole responsibility is to fetch new formulae.
 
-## How to Install ##
-To install `brewupdate`, copy the plist to `~/Library/LaunchAgents` and run the command `launchctl load ~/Library/LaunchAgents/net.mkalmes.brewupdate.plist` to load the LaunchAgent into the launchd manager.
+## How to Install or Upgrade ##
+Run the following command in the terminal:
+
+```sh
+curl -L https://github.com/mkalmes/brewupdate/raw/master/brewupdate-install.sh | bash
+```
+
+### Manual installation ###
+To manually install `brewupdate`, copy the plist to `~/Library/LaunchAgents` and run the command `launchctl load ~/Library/LaunchAgents/net.mkalmes.brewupdate.plist` to load the LaunchAgent into the launchd manager.
 
 Here is a quick rundown:
 ```
@@ -14,7 +21,7 @@ Here is a quick rundown:
 > launchctl load ~/Library/LaunchAgents/net.mkalmes.brewupdate.plist
 ```
 
-## How to Upgrade ##
+### Manual upgrade ###
 If you installed a previous version of brewupdate, unload the loaded LaunchAgent, copy the new agent to `~/Library/LaunchAgents`, and load the copied LaunchAgent.
 
 Here is a quick rundown:

--- a/brewupdate-install.sh
+++ b/brewupdate-install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+AGENTS="$HOME/Library/LaunchAgents"
+PLIST="$AGENTS/net.mkalmes.brewupdate.plist"
+REPO=${BRANCH:-mkalmes}
+BRANCH=${BRANCH:-master}
+REMOTE="https://github.com/$REPO/brewupdate/raw/$BRANCH/net.mkalmes.brewupdate.plist"
+[ -f "$PLIST" ] && launchctl unload "$PLIST"
+if [ "$1" == "uninstall" ]
+then
+  \rm -f "$PLIST"
+  echo "Unloaded brewupdate."
+  exit 0
+fi
+curl -L "$REMOTE" >| "$PLIST"
+[ -f "$PLIST" ] && launchctl load "$PLIST"
+echo "Loaded brewupdate."

--- a/brewupdate-install.sh
+++ b/brewupdate-install.sh
@@ -2,7 +2,7 @@
 set -e
 AGENTS="$HOME/Library/LaunchAgents"
 PLIST="$AGENTS/net.mkalmes.brewupdate.plist"
-REPO=${BRANCH:-mkalmes}
+REPO=${REPO:-mkalmes}
 BRANCH=${BRANCH:-master}
 REMOTE="https://github.com/$REPO/brewupdate/raw/$BRANCH/net.mkalmes.brewupdate.plist"
 [ -f "$PLIST" ] && launchctl unload "$PLIST"


### PR DESCRIPTION
Simplify the process of installing or upgrading `brewupdate` to a single terminal command.  Allows overriding the repo or branch via environment variables.
